### PR TITLE
👽 Add option to use `returnDocument`

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ msg = {
 Notice that the payload from the `deadQueue` is exactly the same as the original message
 when it was on the original queue (except with the number of tries set to 5).
 
+### returnDocument ###
+
+The `mongodb` Node.js driver [deprecated](https://github.com/mongodb/node-mongodb-native/pull/2808)
+use of `returnOriginal` in favor of `returnDocument` when using `findOneAndUpdate()`.
+
+If you want to opt in to using the newer `returnDocument`, set the `returnDocument` option
+to `true`:
+
+```
+var queue = mongoDbQueue(db, 'queue', { returnDocument : true })
+```
+
 ## Operations ##
 
 ### .add() ###


### PR DESCRIPTION
The `mongodb` Node.js driver deprecated use of `returnOriginal` in
favour of `returnDocument` in [v3.6][1].

This non-breaking change allows consumers to opt in to using the newer
`returnDocument` by setting an option on construction

```js
var queue = mongoDbQueue(db, 'queue', { returnDocument : true })
```

[1]: https://github.com/mongodb/node-mongodb-native/pull/2808