### PR TITLE
💥 Require `mongodb` v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "4.0.0-reedsy-1.1.0",
+  "version": "4.0.0-reedsy-2.0.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {
@@ -9,8 +9,11 @@
   "dependencies": {},
   "devDependencies": {
     "async": "^2.6.2",
-    "mongodb": "^3.6.9",
+    "mongodb": "^4.0.0",
     "tape": "^4.10.1"
+  },
+  "peerDependencies": {
+    "mongodb": "^4.0.0"
   },
   "homepage": "https://github.com/chilts/mongodb-queue",
   "repository": {


### PR DESCRIPTION
This change bumps the `mongodb` dependency to v4, and:

 - removes the `returnDocument` option: the deprecated version is no
   longer supported for v4, and we drop its support here
 - update `add()` to check `insertedIds`, since `ops` was removed in v4