### PR TITLE
💥 Promisify and add `mongodb@5` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const client = new mongodb.MongoClient(url, { useNewUrlParser: true })
 
 client.connect(err => {
   const db = client.db('test')
-  const queue = mongoDbQueue(db, 'my-queue')
+  const queue = new MongoDbQueue(db, 'my-queue')
 
   // ...
 
@@ -102,9 +102,9 @@ passed in:
 var mongoDbQueue = require('mongodb-queue')
 
 // an instance of a queue
-var queue1 = mongoDbQueue(db, 'a-queue')
+var queue1 = new MongoDbQueue(db, 'a-queue')
 // another queue which uses the same collection as above
-var queue2 = mongoDbQueue(db, 'a-queue')
+var queue2 = new MongoDbQueue(db, 'a-queue')
 ```
 
 Using `queue1` and `queue2` here won't interfere with each other and will play along nicely, but that's not
@@ -116,7 +116,7 @@ it's not something you should do.
 To pass in options for the queue:
 
 ```
-var resizeQueue = mongoDbQueue(db, 'resize-queue', { visibility : 30, delay : 15 })
+var resizeQueue = new MongoDbQueue(db, 'resize-queue', { visibility : 30, delay : 15 })
 ```
 
 This example shows a queue with a message visibility of 30s and a delay to each message of 15s.
@@ -131,8 +131,8 @@ Each queue you create will be it's own collection.
 e.g.
 
 ```
-var resizeImageQueue = mongoDbQueue(db, 'resize-image-queue')
-var notifyOwnerQueue = mongoDbQueue(db, 'notify-owner-queue')
+var resizeImageQueue = new MongoDbQueue(db, 'resize-image-queue')
+var notifyOwnerQueue = new MongoDbQueue(db, 'notify-owner-queue')
 ```
 
 This will create two collections in MongoDB called `resize-image-queue` and `notify-owner-queue`.
@@ -149,7 +149,7 @@ You may set this visibility window on a per queue basis. For example, to set the
 visibility to 15 seconds:
 
 ```
-var queue = mongoDbQueue(db, 'queue', { visibility : 15 })
+var queue = new MongoDbQueue(db, 'queue', { visibility : 15 })
 ```
 
 All messages in this queue now have a visibility window of 15s, instead of the
@@ -167,7 +167,7 @@ retrieval 10s after being added.
 To delay all messages by 10 seconds, try this:
 
 ```
-var queue = mongoDbQueue(db, 'queue', { delay : 10 })
+var queue = new MongoDbQueue(db, 'queue', { delay : 10 })
 ```
 
 This is now the default for every message added to the queue.
@@ -182,8 +182,8 @@ automatically see problem messages.
 Pass in a queue (that you created) onto which these messages will be pushed:
 
 ```js
-var deadQueue = mongoDbQueue(db, 'dead-queue')
-var queue = mongoDbQueue(db, 'queue', { deadQueue : deadQueue })
+var deadQueue = new MongoDbQueue(db, 'dead-queue')
+var queue = new MongoDbQueue(db, 'queue', { deadQueue : deadQueue })
 ```
 
 If you pop a message off the `queue` over `maxRetries` times and still have not acked it,
@@ -246,7 +246,7 @@ If you want to opt in to using the newer `returnDocument`, set the `returnDocume
 to `true`:
 
 ```
-var queue = mongoDbQueue(db, 'queue', { returnDocument : true })
+var queue = new MongoDbQueue(db, 'queue', { returnDocument : true })
 ```
 
 ## Operations ##

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "4.0.0-reedsy-2.0.1",
+  "version": "4.0.0-reedsy-3.0.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {
@@ -8,12 +8,11 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "async": "^2.6.2",
-    "mongodb": "^4.0.0",
+    "mongodb": "^5.0.0",
     "tape": "^4.10.1"
   },
   "peerDependencies": {
-    "mongodb": "^4.0.0"
+    "mongodb": "^4.0.0 || ^5.0.0"
   },
   "homepage": "https://github.com/chilts/mongodb-queue",
   "repository": {

--- a/test/_timeout.js
+++ b/test/_timeout.js
@@ -1,0 +1,7 @@
+function timeout(millis) {
+  return new Promise((resolve) => setTimeout(resolve, millis))
+}
+
+module.exports = {
+  timeout,
+}

--- a/test/dead-queue.js
+++ b/test/dead-queue.js
@@ -1,178 +1,80 @@
-var async = require('async')
-var test = require('tape')
+const test = require('tape')
 
-var setup = require('./setup.js')
-var mongoDbQueue = require('../')
+const setup = require('./setup.js')
+const MongoDbQueue = require('../')
 
-setup(function(client, db) {
+setup().then(({client, db}) => {
 
-    test('first test', function(t) {
-        var queue = mongoDbQueue(db, 'queue', { visibility : 3, deadQueue : 'dead-queue' })
+    test('first test', function (t) {
+        const queue = new MongoDbQueue(db, 'queue', {visibility: 3, deadQueue: 'dead-queue'})
         t.ok(queue, 'Queue created ok')
         t.end()
     });
 
-    test('single message going over 5 tries, should appear on dead-queue', function(t) {
-        var deadQueue = mongoDbQueue(db, 'dead-queue')
-        var queue = mongoDbQueue(db, 'queue', { visibility : 1, deadQueue : deadQueue })
-        var msg
-        var origId
+    test('single message going over 5 tries, should appear on dead-queue', async function (t) {
+        const deadQueue = new MongoDbQueue(db, 'dead-queue')
+        const queue = new MongoDbQueue(db, 'queue', {visibility: 1, deadQueue: deadQueue})
+        let msg
+        let origId
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err, id) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        t.ok(id, 'Received an id for this message')
-                        origId = id
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        setTimeout(function() {
-                            t.pass('First expiration')
-                            next()
-                        }, 2 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        setTimeout(function() {
-                            t.pass('Second expiration')
-                            next()
-                        }, 2 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        setTimeout(function() {
-                            t.pass('Third expiration')
-                            next()
-                        }, 2 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        setTimeout(function() {
-                            t.pass('Fourth expiration')
-                            next()
-                        }, 2 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        setTimeout(function() {
-                            t.pass('Fifth expiration')
-                            next()
-                        }, 2 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, id) {
-                        t.ok(!err, 'No error when getting no messages')
-                        t.ok(!msg, 'No msg received')
-                        next()
-                    })
-                },
-                function(next) {
-                    deadQueue.get(function(err, msg) {
-                        t.ok(!err, 'No error when getting from the deadQueue')
-                        t.ok(msg.id, 'Got a message id from the deadQueue')
-                        t.equal(msg.payload.id, origId, 'Got the same message id as the original message')
-                        t.equal(msg.payload.payload, 'Hello, World!', 'Got the same as the original message')
-                        t.equal(msg.payload.tries, 6, 'Got the tries as 6')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                t.ok(!err, 'No error during single round-trip test')
-                t.end()
-            }
-        )
+        origId = await queue.add('Hello, World!')
+        t.ok(origId, 'Received an id for this message')
+
+        await queue.get()
+
+        for (let i = 1; i <= 5; i++) {
+            await queue.get()
+            await new Promise((resolve) => setTimeout(function () {
+                t.pass(`Expiration #${i}`)
+                resolve()
+            }, 2 * 1000))
+        }
+
+        msg = await queue.get()
+        t.ok(!msg, 'No msg received')
+
+        msg = await deadQueue.get()
+        t.ok(msg.id, 'Got a message id from the deadQueue')
+        t.equal(msg.payload.id, origId, 'Got the same message id as the original message')
+        t.equal(msg.payload.payload, 'Hello, World!', 'Got the same as the original message')
+        t.equal(msg.payload.tries, 6, 'Got the tries as 6')
+
+        t.end()
     })
 
-    test('two messages, with first going over 3 tries', function(t) {
-        var deadQueue = mongoDbQueue(db, 'dead-queue-2')
-        var queue = mongoDbQueue(db, 'queue-2', { visibility : 1, deadQueue : deadQueue, maxRetries : 3 })
-        var msg
-        var origId, origId2
+    test('two messages, with first going over 3 tries', async function (t) {
+        const deadQueue = new MongoDbQueue(db, 'dead-queue-2')
+        const queue = new MongoDbQueue(db, 'queue-2', {visibility: 1, deadQueue: deadQueue, maxRetries: 3})
+        let msg
+        let origId, origId2
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err, id) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        t.ok(id, 'Received an id for this message')
-                        origId = id
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.add('Part II', function(err, id) {
-                        t.ok(!err, 'There is no error when adding another message.')
-                        t.ok(id, 'Received an id for this message')
-                        origId2 = id
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        t.equal(thisMsg.id, origId, 'We return the first message on first go')
-                        setTimeout(function() {
-                            t.pass('First expiration')
-                            next()
-                        }, 2 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        t.equal(thisMsg.id, origId, 'We return the first message on second go')
-                        setTimeout(function() {
-                            t.pass('Second expiration')
-                            next()
-                        }, 2 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        t.equal(thisMsg.id, origId, 'We return the first message on third go')
-                        setTimeout(function() {
-                            t.pass('Third expiration')
-                            next()
-                        }, 2 * 1000)
-                    })
-                },
-                function(next) {
-                    // This is the 4th time, so we SHOULD have moved it to the dead queue
-                    // pior to it being returned.
-                    queue.get(function(err, msg) {
-                        t.ok(!err, 'No error when getting the 2nd message')
-                        t.equal(msg.id, origId2, 'Got the ID of the 2nd message')
-                        t.equal(msg.payload, 'Part II', 'Got the same payload as the 2nd message')
-                        next()
-                    })
-                },
-                function(next) {
-                    deadQueue.get(function(err, msg) {
-                        t.ok(!err, 'No error when getting from the deadQueue')
-                        t.ok(msg.id, 'Got a message id from the deadQueue')
-                        t.equal(msg.payload.id, origId, 'Got the same message id as the original message')
-                        t.equal(msg.payload.payload, 'Hello, World!', 'Got the same as the original message')
-                        t.equal(msg.payload.tries, 4, 'Got the tries as 4')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                t.ok(!err, 'No error during single round-trip test')
-                t.end()
-            }
-        )
+        origId = await queue.add('Hello, World!')
+        t.ok(origId, 'Received an id for this message')
+        origId2 = await queue.add('Part II')
+        t.ok(origId2, 'Received an id for this message')
+
+        for (let i = 1; i <= 3; i++) {
+            msg = await queue.get()
+            t.equal(msg.id, origId, 'We return the first message on first go')
+            await new Promise((resolve) => setTimeout(function () {
+                t.pass(`Expiration #${i}`)
+                resolve()
+            }, 2 * 1000))
+        }
+
+        msg = await queue.get()
+        t.equal(msg.id, origId2, 'Got the ID of the 2nd message')
+        t.equal(msg.payload, 'Part II', 'Got the same payload as the 2nd message')
+
+        msg = await deadQueue.get()
+        t.ok(msg.id, 'Got a message id from the deadQueue')
+        t.equal(msg.payload.id, origId, 'Got the same message id as the original message')
+        t.equal(msg.payload.payload, 'Hello, World!', 'Got the same as the original message')
+        t.equal(msg.payload.tries, 4, 'Got the tries as 4')
+        t.end()
     })
 
-    test('client.close()', function(t) {
+    test('client.close()', function (t) {
         t.pass('client.close()')
         client.close()
         t.end()

--- a/test/default.js
+++ b/test/default.js
@@ -1,110 +1,65 @@
-var async = require('async')
-var test = require('tape')
+const test = require('tape')
 
-var setup = require('./setup.js')
-var mongoDbQueue = require('../')
+const setup = require('./setup.js')
+const MongoDbQueue = require('../')
 
-setup(function(client, db) {
+setup().then(({client, db}) => {
 
-    test('first test', function(t) {
-        var queue = mongoDbQueue(db, 'default')
+    test('first test', function (t) {
+        const queue = new MongoDbQueue(db, 'default')
         t.ok(queue, 'Queue created ok')
         t.end()
     });
 
-    test('single round trip', function(t) {
-        var queue = mongoDbQueue(db, 'default')
-        var msg
+    test('single round trip', async function (t) {
+        const queue = new MongoDbQueue(db, 'default')
+        let msg
+        let id
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err, id) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        t.ok(id, 'Received an id for this message')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        console.log(thisMsg)
-                        msg = thisMsg
-                        t.ok(msg.id, 'Got a msg.id')
-                        t.equal(typeof msg.id, 'string', 'msg.id is a string')
-                        t.ok(msg.ack, 'Got a msg.ack')
-                        t.equal(typeof msg.ack, 'string', 'msg.ack is a string')
-                        t.ok(msg.tries, 'Got a msg.tries')
-                        t.equal(typeof msg.tries, 'number', 'msg.tries is a number')
-                        t.equal(msg.tries, 1, 'msg.tries is currently one')
-                        t.equal(msg.payload, 'Hello, World!', 'Payload is correct')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.ack(msg.ack, function(err, id) {
-                        t.ok(!err, 'No error when acking the message')
-                        t.ok(id, 'Received an id when acking this message')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                t.ok(!err, 'No error during single round-trip test')
-                t.end()
-            }
-        )
+        id = await queue.add('Hello, World!')
+        t.ok(id, 'Received an id for this message')
+
+        msg = await queue.get()
+        t.ok(msg.id, 'Got a msg.id')
+        t.equal(typeof msg.id, 'string', 'msg.id is a string')
+        t.ok(msg.ack, 'Got a msg.ack')
+        t.equal(typeof msg.ack, 'string', 'msg.ack is a string')
+        t.ok(msg.tries, 'Got a msg.tries')
+        t.equal(typeof msg.tries, 'number', 'msg.tries is a number')
+        t.equal(msg.tries, 1, 'msg.tries is currently one')
+        t.equal(msg.payload, 'Hello, World!', 'Payload is correct')
+
+        id = await queue.ack(msg.ack)
+        t.ok(id, 'Received an id when acking this message')
+        t.end()
     })
 
-    test("single round trip, can't be acked again", function(t) {
-        var queue = mongoDbQueue(db, 'default')
-        var msg
+    test("single round trip, can't be acked again", async function (t) {
+        const queue = new MongoDbQueue(db, 'default')
+        let msg
+        let id
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err, id) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        t.ok(id, 'Received an id for this message')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, thisMsg) {
-                        msg = thisMsg
-                        t.ok(msg.id, 'Got a msg.id')
-                        t.equal(typeof msg.id, 'string', 'msg.id is a string')
-                        t.ok(msg.ack, 'Got a msg.ack')
-                        t.equal(typeof msg.ack, 'string', 'msg.ack is a string')
-                        t.ok(msg.tries, 'Got a msg.tries')
-                        t.equal(typeof msg.tries, 'number', 'msg.tries is a number')
-                        t.equal(msg.tries, 1, 'msg.tries is currently one')
-                        t.equal(msg.payload, 'Hello, World!', 'Payload is correct')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.ack(msg.ack, function(err, id) {
-                        t.ok(!err, 'No error when acking the message')
-                        t.ok(id, 'Received an id when acking this message')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.ack(msg.ack, function(err, id) {
-                        t.ok(err, 'There is an error when acking the message again')
-                        t.ok(!id, 'No id received when trying to ack an already deleted message')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                t.ok(!err, 'No error during single round-trip when trying to double ack')
-                t.end()
-            }
-        )
+        id = await queue.add('Hello, World!')
+        t.ok(id, 'Received an id for this message')
+        msg = await queue.get()
+        t.ok(msg.id, 'Got a msg.id')
+        t.equal(typeof msg.id, 'string', 'msg.id is a string')
+        t.ok(msg.ack, 'Got a msg.ack')
+        t.equal(typeof msg.ack, 'string', 'msg.ack is a string')
+        t.ok(msg.tries, 'Got a msg.tries')
+        t.equal(typeof msg.tries, 'number', 'msg.tries is a number')
+        t.equal(msg.tries, 1, 'msg.tries is currently one')
+        t.equal(msg.payload, 'Hello, World!', 'Payload is correct')
+        id = await queue.ack(msg.ack)
+        t.ok(id, 'Received an id when acking this message')
+        id = await queue.ack(msg.ack)
+            .catch((err) => t.ok(err, 'There is an error when acking the message again'))
+
+        t.ok(!id, 'No id received when trying to ack an already deleted message')
+        t.end()
     })
 
-    test('client.close()', function(t) {
+    test('client.close()', function (t) {
         t.pass('client.close()')
         client.close()
         t.end()

--- a/test/delay.js
+++ b/test/delay.js
@@ -1,104 +1,57 @@
-var async = require('async')
-var test = require('tape')
+const test = require('tape')
 
-var setup = require('./setup.js')
-var mongoDbQueue = require('../')
+const setup = require('./setup.js')
+const MongoDbQueue = require('../')
+const {timeout} = require('./_timeout.js')
 
-setup(function(client, db) {
+setup().then(({client, db}) => {
 
-    test('delay: check messages on this queue are returned after the delay', function(t) {
-        var queue = mongoDbQueue(db, 'delay', { delay : 3 })
+    test('delay: check messages on this queue are returned after the delay', async function (t) {
+        const queue = new MongoDbQueue(db, 'delay', {delay: 3})
+        let id
+        let msg
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err, id) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        t.ok(id, 'There is an id returned when adding a message.')
-                        next()
-                    })
-                },
-                function(next) {
-                    // get something now and it shouldn't be there
-                    queue.get(function(err, msg) {
-                        t.ok(!err, 'No error when getting no messages')
-                        t.ok(!msg, 'No msg received')
-                        // now wait 4s
-                        setTimeout(next, 4 * 1000)
-                    })
-                },
-                function(next) {
-                    // get something now and it SHOULD be there
-                    queue.get(function(err, msg) {
-                        t.ok(!err, 'No error when getting a message')
-                        t.ok(msg.id, 'Got a message id now that the message delay has passed')
-                        queue.ack(msg.ack, next)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // no more messages
-                        t.ok(!err, 'No error when getting no messages')
-                        t.ok(!msg, 'No more messages')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                if (err) t.fail(err)
-                t.pass('Finished test ok')
-                t.end()
-            }
-        )
+        id = await queue.add('Hello, World!')
+        t.ok(id, 'There is an id returned when adding a message.')
+        // get something now and it shouldn't be there
+        msg = await queue.get()
+        t.ok(!msg, 'No msg received')
+        await timeout(4_000)
+        // get something now and it SHOULD be there
+        msg = await queue.get()
+        t.ok(msg.id, 'Got a message id now that the message delay has passed')
+        await queue.ack(msg.ack)
+        msg = await queue.get()
+        // no more messages
+        t.ok(!msg, 'No more messages')
+        t.pass('Finished test ok')
+        t.end()
     })
 
-    test('delay: check an individual message delay overrides the queue delay', function(t) {
-        var queue = mongoDbQueue(db, 'delay')
+    test('delay: check an individual message delay overrides the queue delay', async function (t) {
+        const queue = new MongoDbQueue(db, 'delay')
+        let id
+        let msg
 
-        async.series(
-            [
-                function(next) {
-                  queue.add('I am delayed by 3 seconds', { delay : 3 }, function(err, id) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        t.ok(id, 'There is an id returned when adding a message.')
-                        next()
-                    })
-                },
-                function(next) {
-                    // get something now and it shouldn't be there
-                    queue.get(function(err, msg) {
-                        t.ok(!err, 'No error when getting no messages')
-                        t.ok(!msg, 'No msg received')
-                        // now wait 4s
-                        setTimeout(next, 4 * 1000)
-                    })
-                },
-                function(next) {
-                    // get something now and it SHOULD be there
-                    queue.get(function(err, msg) {
-                        t.ok(!err, 'No error when getting a message')
-                        t.ok(msg.id, 'Got a message id now that the message delay has passed')
-                        queue.ack(msg.ack, next)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // no more messages
-                        t.ok(!err, 'No error when getting no messages')
-                        t.ok(!msg, 'No more messages')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                if (err) t.fail(err)
-                t.pass('Finished test ok')
-                t.end()
-            }
-        )
+        id = await queue.add('I am delayed by 3 seconds', {delay: 3})
+        t.ok(id, 'There is an id returned when adding a message.')
+        // get something now and it shouldn't be there
+        msg = await queue.get()
+        t.ok(!msg, 'No msg received')
+        await timeout(4_000)
+        // get something now and it SHOULD be there
+        msg = await queue.get()
+        t.ok(msg.id, 'Got a message id now that the message delay has passed')
+        await queue.ack(msg.ack)
+        msg = await queue.get()
+        // no more messages
+        t.ok(!msg, 'No more messages')
+
+        t.pass('Finished test ok')
+        t.end()
     })
 
-    test('client.close()', function(t) {
+    test('client.close()', function (t) {
         t.pass('client.close()')
         client.close()
         t.end()

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -1,21 +1,16 @@
-var async = require('async')
-var test = require('tape')
+const test = require('tape')
 
-var setup = require('./setup.js')
-var mongoDbQueue = require('../')
+const setup = require('./setup.js')
+const MongoDbQueue = require('../')
 
-setup(function(client, db) {
+setup().then(({client, db}) => {
 
-    test('visibility: check message is back in queue after 3s', function(t) {
-        t.plan(2)
+    test('visibility: check message is back in queue after 3s', async function(t) {
+        const queue = new MongoDbQueue(db, 'visibility', { visibility : 3 })
 
-        var queue = mongoDbQueue(db, 'visibility', { visibility : 3 })
-
-        queue.createIndexes(function(err, indexName) {
-            t.ok(!err, 'There was no error when running .ensureIndexes()')
-            t.ok(indexName, 'receive indexName we created')
-            t.end()
-        })
+        await queue.createIndexes()
+        t.pass('Indexes created')
+        t.end()
     })
 
     test('client.close()', function(t) {

--- a/test/many.js
+++ b/test/many.js
@@ -1,80 +1,50 @@
-var async = require('async')
-var test = require('tape')
+const test = require('tape')
 
-var setup = require('./setup.js')
-var mongoDbQueue = require('../')
+const setup = require('./setup.js')
+const MongoDbQueue = require('../')
 
-var total = 250
+const total = 250
 
-setup(function(client, db) {
+setup().then(({client, db}) => {
 
-    test('many: add ' + total + ' messages, get ' + total + ' back', function(t) {
-        var queue = mongoDbQueue(db, 'many')
-        var msgs = []
-        var msgsToQueue = []
+    test('many: add ' + total + ' messages, get ' + total + ' back', async function (t) {
+        const queue = new MongoDbQueue(db, 'many')
+        const msgs = []
+        const msgsToQueue = []
 
-        async.series(
-            [
-                function(next) {
-                    var i
-                    for(i=0; i<total; i++) {
-                        msgsToQueue.push('no=' + i)
-                    }
-                    queue.add(msgsToQueue, function(err) {
-                        if (err) return t.fail('Failed adding a message')
-                        t.pass('All ' + total + ' messages sent to MongoDB')
-                        next()
-                    })
-                },
-                function(next) {
-                    function getOne() {
-                        queue.get(function(err, msg) {
-                            if (err || !msg) return t.fail('Failed getting a message')
-                            msgs.push(msg)
-                            if (msgs.length === total) {
-                                t.pass('Received all ' + total + ' messages')
-                                next()
-                            }
-                            else {
-                                getOne()
-                            }
-                        })
-                    }
-                    getOne()
-                },
-                function(next) {
-                    var acked = 0
-                    msgs.forEach(function(msg) {
-                        queue.ack(msg.ack, function(err) {
-                            if (err) return t.fail('Failed acking a message')
-                            acked++
-                            if (acked === total) {
-                                t.pass('Acked all ' + total + ' messages')
-                                next()
-                            }
-                        })
-                    })
-                },
-            ],
-            function(err) {
-                if (err) t.fail(err)
-                t.pass('Finished test ok')
-                t.end()
-            }
+
+        for (let i = 0; i < total; i++) {
+            msgsToQueue.push('no=' + i)
+        }
+        await queue.add(msgsToQueue)
+        t.pass('All ' + total + ' messages sent to MongoDB')
+
+        async function getOne() {
+            const msg = await queue.get()
+            if (!msg) return t.fail('Failed getting a message')
+            msgs.push(msg)
+            if (msgs.length !== total) return getOne()
+            t.pass('Received all ' + total + ' messages')
+        }
+        await getOne()
+
+        await Promise.all(
+            msgs.map((msg) => queue.ack(msg.ack))
         )
+
+        t.pass('Acked all ' + total + ' messages')
+        t.pass('Finished test ok')
+        t.end()
     })
 
-    test('many: add no messages, receive err in callback', function(t) {
-        var queue = mongoDbQueue(db, 'many')
-        var messages = []
-        queue.add([], function(err) {
-            if (!err) t.fail('Error was not received')
-            t.pass('Finished test ok')
-            t.end()
-        });
+    test('many: add no messages, receive err in callback', async function (t) {
+        const queue = new MongoDbQueue(db, 'many')
+        await queue.add([])
+            .catch(() => t.pass('got error'))
+        t.end()
     })
 
-    test('client.close()', function(t) {
+    test('client.close()', function (t) {
         t.pass('client.close()')
         client.close()
         t.end()

--- a/test/multi.js
+++ b/test/multi.js
@@ -1,71 +1,37 @@
-var async = require('async')
-var test = require('tape')
+const test = require('tape')
 
-var setup = require('./setup.js')
-var mongoDbQueue = require('../')
+const setup = require('./setup.js')
+const MongoDbQueue = require('../')
 
-var total = 250
+const total = 250
 
-setup(function(client, db) {
+setup().then(({client, db}) => {
 
-    test('multi: add ' + total + ' messages, get ' + total + ' back', function(t) {
-        var queue = mongoDbQueue(db, 'multi')
-        var msgs = []
+    test('multi: add ' + total + ' messages, get ' + total + ' back', async function (t) {
+        const queue = new MongoDbQueue(db, 'multi')
+        const msgs = []
 
-        async.series(
-            [
-                function(next) {
-                    var i, done = 0
-                    for(i=0; i<total; i++) {
-                        queue.add('no=' + i, function(err) {
-                            if (err) return t.fail('Failed adding a message')
-                            done++
-                            if (done === total) {
-                                t.pass('All ' + total + ' messages sent to MongoDB')
-                                next()
-                            }
-                        })
-                    }
-                },
-                function(next) {
-                    function getOne() {
-                        queue.get(function(err, msg) {
-                            if (err) return t.fail('Failed getting a message')
-                            msgs.push(msg)
-                            if (msgs.length === total) {
-                                t.pass('Received all ' + total + ' messages')
-                                next()
-                            }
-                            else {
-                                getOne()
-                            }
-                        })
-                    }
-                    getOne()
-                },
-                function(next) {
-                    var acked = 0
-                    msgs.forEach(function(msg) {
-                        queue.ack(msg.ack, function(err) {
-                            if (err) return t.fail('Failed acking a message')
-                            acked++
-                            if (acked === total) {
-                                t.pass('Acked all ' + total + ' messages')
-                                next()
-                            }
-                        })
-                    })
-                },
-            ],
-            function(err) {
-                if (err) t.fail(err)
-                t.pass('Finished test ok')
-                t.end()
-            }
+        for (let i = 0; i < total; i++) await queue.add('no=' + i)
+        t.pass('All ' + total + ' messages sent to MongoDB')
+
+        async function getOne() {
+            const msg = await queue.get()
+            msgs.push(msg)
+            if (msgs.length !== total) return getOne()
+            t.pass('Received all ' + total + ' messages')
+        }
+        await getOne()
+
+        await Promise.all(
+            msgs.map((msg) => queue.ack(msg.ack))
         )
+
+        t.pass('Acked all ' + total + ' messages')
+
+        t.end()
     })
 
-    test('client.close()', function(t) {
+    test('client.close()', function (t) {
         t.pass('client.close()')
         client.close()
         t.end()

--- a/test/setup.js
+++ b/test/setup.js
@@ -18,25 +18,14 @@ const collections = [
   'dead-queue-2',
 ]
 
-module.exports = function(callback) {
+module.exports = async function() {
   const client = new mongodb.MongoClient(url, { useNewUrlParser: true })
 
-  client.connect(err => {
-    // we can throw since this is test-only
-    if (err) throw err
+  await client.connect()
+  const db = client.db(dbName)
 
-    const db = client.db(dbName)
-
-    // empty out some collections to make sure there are no messages
-    let done = 0
-    collections.forEach((col) => {
-      db.collection(col).deleteMany(() => {
-        done += 1
-        if ( done === collections.length ) {
-          callback(client, db)
-        }
-      })
-    })
-  })
-
+  await Promise.all(
+      collections.map((col) => db.collection(col).deleteMany())
+  )
+  return {client, db}
 }

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,204 +1,71 @@
-var async = require('async')
-var test = require('tape')
+const test = require('tape')
+const {timeout} = require('./_timeout')
 
-var setup = require('./setup.js')
-var mongoDbQueue = require('../')
+const setup = require('./setup.js')
+const MongoDbQueue = require('../')
 
-setup(function(client, db) {
+setup().then(({client, db}) => {
 
-    test('first test', function(t) {
-        var queue = mongoDbQueue(db, 'stats')
+    test('first test', function (t) {
+        const queue = new MongoDbQueue(db, 'stats')
         t.ok(queue, 'Queue created ok')
         t.end()
     });
 
-    test('stats for a single message added, received and acked', function(t) {
-        var queue = mongoDbQueue(db, 'stats1')
-        var msg
+    test('stats for a single message added, received and acked', async function (t) {
+        const q = new MongoDbQueue(db, 'stats1')
+        let msg
+        let id
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err, id) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        t.ok(id, 'Received an id for this message')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.total(function(err, count) {
-                        t.equal(count, 1, 'Total number of messages is one')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.size(function(err, count) {
-                        t.equal(count, 1, 'Size of queue is one')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.inFlight(function(err, count) {
-                        t.equal(count, 0, 'There are no inFlight messages')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.done(function(err, count) {
-                        t.equal(count, 0, 'There are no done messages')
-                        next()
-                    })
-                },
-                function(next) {
-                    // let's set one to be inFlight
-                    queue.get(function(err, newMsg) {
-                        msg = newMsg
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.total(function(err, count) {
-                        t.equal(count, 1, 'Total number of messages is still one')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.size(function(err, count) {
-                        t.equal(count, 0, 'Size of queue is now zero (ie. none to come)')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.inFlight(function(err, count) {
-                        t.equal(count, 1, 'There is one inflight message')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.done(function(err, count) {
-                        t.equal(count, 0, 'There are still no done messages')
-                        next()
-                    })
-                },
-                function(next) {
-                    // now ack that message
-                    queue.ack(msg.ack, function(err, newMsg) {
-                        msg = newMsg
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.total(function(err, count) {
-                        t.equal(count, 1, 'Total number of messages is again one')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.size(function(err, count) {
-                        t.equal(count, 0, 'Size of queue is still zero (ie. none to come)')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.inFlight(function(err, count) {
-                        t.equal(count, 0, 'There are no inflight messages anymore')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.done(function(err, count) {
-                        t.equal(count, 1, 'There is now one processed message')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                t.ok(!err, 'No error when doing stats on one message')
-                t.end()
-            }
-        )
+        id = await q.add('Hello, World!')
+        t.ok(id, 'Received an id for this message')
+        t.equal(await q.total(), 1, 'Total number of messages is one')
+        t.equal(await q.size(), 1, 'Size of queue is one')
+        t.equal(await q.inFlight(), 0, 'There are no inFlight messages')
+        t.equal(await q.done(), 0, 'There are no done messages')
+        msg = await q.get()
+        t.equal(await q.total(), 1, 'Total number of messages is still one')
+        t.equal(await q.size(), 0, 'Size of queue is now zero (ie. none to come)')
+        t.equal(await q.inFlight(), 1, 'There is one inflight message')
+        t.equal(await q.done(), 0, 'There are still no done messages')
+        // now ack that message
+        msg = await q.ack(msg.ack)
+        t.equal(await q.total(), 1, 'Total number of messages is again one')
+        t.equal(await q.size(), 0, 'Size of queue is still zero (ie. none to come)')
+        t.equal(await q.inFlight(), 0, 'There are no inflight messages anymore')
+        t.equal(await q.done(), 1, 'There is now one processed message')
+
+        t.end()
     })
 
 
     // ToDo: add more tests for adding a message, getting it and letting it lapse
     // then re-checking all stats.
 
-    test('stats for a single message added, received, timed-out and back on queue', function(t) {
-        var queue = mongoDbQueue(db, 'stats2', { visibility : 3 })
+    test('stats for a single message added, received, timed-out and back on queue', async function (t) {
+        const q = new MongoDbQueue(db, 'stats2', {visibility: 3})
+        let id
+        let msg
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err, id) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        t.ok(id, 'Received an id for this message')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.total(function(err, count) {
-                        t.equal(count, 1, 'Total number of messages is one')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.size(function(err, count) {
-                        t.equal(count, 1, 'Size of queue is one')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.inFlight(function(err, count) {
-                        t.equal(count, 0, 'There are no inFlight messages')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.done(function(err, count) {
-                        t.equal(count, 0, 'There are no done messages')
-                        next()
-                    })
-                },
-                function(next) {
-                    // let's set one to be inFlight
-                    queue.get(function(err, msg) {
-                        // msg is ignored, we don't care about the message here
-                        setTimeout(next, 4 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.total(function(err, count) {
-                        t.equal(count, 1, 'Total number of messages is still one')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.size(function(err, count) {
-                        t.equal(count, 1, 'Size of queue is still at one')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.inFlight(function(err, count) {
-                        t.equal(count, 0, 'There are no inflight messages again')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.done(function(err, count) {
-                        t.equal(count, 0, 'There are still no done messages')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                t.ok(!err, 'No error when doing stats on one message')
-                t.end()
-            }
-        )
+        id = await q.add('Hello, World!')
+        t.ok(id, 'Received an id for this message')
+        t.equal(await q.total(), 1, 'Total number of messages is one')
+        t.equal(await q.size(), 1, 'Size of queue is one')
+        t.equal(await q.inFlight(), 0, 'There are no inFlight messages')
+        t.equal(await q.done(), 0, 'There are no done messages')
+        // let's set one to be inFlight
+        msg = await q.get()
+        // msg is ignored, we don't care about the message here
+        await timeout(4_000)
+        t.equal(await q.total(), 1, 'Total number of messages is still one')
+        t.equal(await q.size(), 1, 'Size of queue is still at one')
+        t.equal(await q.inFlight(), 0, 'There are no inflight messages again')
+        t.equal(await q.done(), 0, 'There are still no done messages')
+
+        t.end()
     })
 
-    test('client.close()', function(t) {
+    test('client.close()', function (t) {
         t.pass('client.close()')
         client.close()
         t.end()

--- a/test/visibility.js
+++ b/test/visibility.js
@@ -1,171 +1,90 @@
-var async = require('async')
-var test = require('tape')
+const test = require('tape')
+const {timeout} = require('./_timeout')
 
-var setup = require('./setup.js')
-var mongoDbQueue = require('../')
+const setup = require('./setup.js')
+const MongoDbQueue = require('../')
 
-setup(function(client, db) {
+setup().then(({client, db}) => {
 
-    test('visibility: check message is back in queue after 3s', function(t) {
-        var queue = mongoDbQueue(db, 'visibility', { visibility : 3 })
+    test('visibility: check message is back in queue after 3s', async function (t) {
+        const queue = new MongoDbQueue(db, 'visibility', {visibility: 3})
+        let msg
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // wait over 3s so the msg returns to the queue
-                        t.ok(msg.id, 'Got a msg.id (sanity check)')
-                        setTimeout(next, 4 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // yes, there should be a message on the queue again
-                        t.ok(msg.id, 'Got a msg.id (sanity check)')
-                        queue.ack(msg.ack, function(err) {
-                            t.ok(!err, 'No error when acking the message')
-                            next()
-                        })
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // no more messages
-                        t.ok(!err, 'No error when getting no messages')
-                        t.ok(!msg, 'No msg received')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                if (err) t.fail(err)
-                t.pass('Finished test ok')
-                t.end()
-            }
-        )
+        await queue.add('Hello, World!')
+        msg = await queue.get()
+        t.ok(msg.id, 'Got a msg.id (sanity check)')
+        await timeout(4_000)
+        msg = await queue.get()
+        // yes, there should be a message on the queue again
+        t.ok(msg.id, 'Got a msg.id (sanity check)')
+        await queue.ack(msg.ack)
+        msg = await queue.get()
+        t.ok(!msg, 'No msg received')
+
+        t.pass('Finished test ok')
+        t.end()
     })
 
-    test("visibility: check that a late ack doesn't remove the msg", function(t) {
-        var queue = mongoDbQueue(db, 'visibility', { visibility : 3 })
-        var originalAck
+    test("visibility: check that a late ack doesn't remove the msg", async function (t) {
+        const queue = new MongoDbQueue(db, 'visibility', {visibility: 3})
+        let originalAck
+        let msg
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        t.ok(msg.id, 'Got a msg.id (sanity check)')
+        await queue.add('Hello, World!')
+        msg = await queue.get()
+        t.ok(msg.id, 'Got a msg.id (sanity check)')
+        // remember this original ack
+        originalAck = msg.ack
+        // wait over 3s so the msg returns to the queue
+        await timeout(4_000)
 
-                        // remember this original ack
-                        originalAck = msg.ack
+        t.pass('Back from timeout, now acking the message')
 
-                        // wait over 3s so the msg returns to the queue
-                        setTimeout(function() {
-                            t.pass('Back from timeout, now acking the message')
+        // now ack the message but too late - it shouldn't be deleted
+        msg = await queue.ack(msg.ack)
+            .catch((err) => t.ok(err, 'Got an error when acking the message late'))
+        t.ok(!msg, 'No message was updated')
+        msg = await queue.get()
+        // the message should now be able to be retrieved, with a new 'ack' id
+        t.ok(msg.id, 'Got a msg.id (sanity check)')
+        t.notEqual(msg.ack, originalAck, 'Original ack and new ack are different')
 
-                            // now ack the message but too late - it shouldn't be deleted
-                            queue.ack(msg.ack, function(err, msg) {
-                                t.ok(err, 'Got an error when acking the message late')
-                                t.ok(!msg, 'No message was updated')
-                                next()
-                            })
-                        }, 4 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // the message should now be able to be retrieved, with a new 'ack' id
-                        t.ok(msg.id, 'Got a msg.id (sanity check)')
-                        t.notEqual(msg.ack, originalAck, 'Original ack and new ack are different')
+        // now ack this new retrieval
+        await queue.ack(msg.ack)
+        msg = await queue.get()
 
-                        // now ack this new retrieval
-                        queue.ack(msg.ack, next)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // no more messages
-                        t.ok(!err, 'No error when getting no messages')
-                        t.ok(!msg, 'No msg received')
-                        next()
-                    })
-                },
-            ],
-            function(err) {
-                if (err) t.fail(err)
-                t.pass('Finished test ok')
-                t.end()
-            }
-        )
+        // no more messages
+        t.ok(!msg, 'No msg received')
+
+        t.pass('Finished test ok')
+        t.end()
     })
 
-    test("visibility: check visibility option overrides the queue visibility", function(t) {
-        var queue = mongoDbQueue(db, 'visibility', { visibility : 2 })
-        var originalAck
+    test("visibility: check visibility option overrides the queue visibility", async function (t) {
+        const queue = new MongoDbQueue(db, 'visibility', {visibility: 2})
+        let msg
 
-        async.series(
-            [
-                function(next) {
-                    queue.add('Hello, World!', function(err) {
-                        t.ok(!err, 'There is no error when adding a message.')
-                        next()
-                    })
-                },
-                function(next) {
-                    queue.get({ visibility: 4 }, function(err, msg) {
-                        // wait over 2s so the msg would normally have returns to the queue
-                        t.ok(msg.id, 'Got a msg.id (sanity check)')
-                        setTimeout(next, 3 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // messages should not be back yet
-                        t.ok(!err, 'No error when getting no messages')
-                        t.ok(!msg, 'No msg received')
-                        // wait 2s so the msg should have returns to the queue
-                        setTimeout(next, 2 * 1000)
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // yes, there should be a message on the queue again
-                        t.ok(msg.id, 'Got a msg.id (sanity check)')
-                        queue.ack(msg.ack, function(err) {
-                            t.ok(!err, 'No error when acking the message')
-                            next()
-                        })
-                    })
-                },
-                function(next) {
-                    queue.get(function(err, msg) {
-                        // no more messages
-                        t.ok(!err, 'No error when getting no messages')
-                        t.ok(!msg, 'No msg received')
-                        next()
-                    })
-                }
-            ],
-            function(err) {
-                if (err) t.fail(err)
-                t.pass('Finished test ok')
-                t.end()
-            }
-        )
+        await queue.add('Hello, World!')
+        msg = await queue.get({visibility: 4})
+        t.ok(msg.id, 'Got a msg.id (sanity check)')
+        // wait over 2s so the msg would normally have returns to the queue
+        await timeout(3_000)
+        msg = await queue.get()
+        t.ok(!msg, 'No msg received')
+        // wait 2s so the msg should have returns to the queue
+        await timeout(2_000)
+        msg = await queue.get()
+        t.ok(msg.id, 'Got a msg.id (sanity check)')
+        await queue.ack(msg.ack)
+        msg = await queue.get()
+        // no more messages
+        t.ok(!msg, 'No msg received')
+
+        t.pass('Finished test ok')
+        t.end()
     })
 
-    test('client.close()', function(t) {
+    test('client.close()', function (t) {
         t.pass('client.close()')
         client.close()
         t.end()


### PR DESCRIPTION
[`mongodb@5`][1] drops support for callbacks, which breaks this library, which is all written with callbacks.

This is a **BREAKING** change which drops callback support from this library as well, and fully embraces promises through `async`/`await` syntax in both the library code and test code.

This allows us to support both `mongodb@4` and `mongodb@5`.

[1]: https://github.com/mongodb/node-mongodb-native/releases/tag/v5.0.0