### PR TITLE
⬆️ Add support for `mongodb@6`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
         mongo_driver:
         - mongodb4
         - mongodb5
+        - mongodb6
     services:
       mongodb:
         image: mongo:${{ matrix.mongodb }}

--- a/mongodb-queue.ts
+++ b/mongodb-queue.ts
@@ -139,10 +139,11 @@ export default class Queue<T = any> {
         visible: nowPlusSecs(visibility),
       },
     };
-    const options: FindOneAndUpdateOptions = {
+    const options = {
       sort: sort,
       returnDocument: 'after',
-    };
+      includeResultMetadata: true,
+    } satisfies FindOneAndUpdateOptions;
 
     const result = await this.col.findOneAndUpdate(query, update, options);
     const msg = result.value as WithId<Message<T>>;
@@ -183,9 +184,10 @@ export default class Queue<T = any> {
         visible: nowPlusSecs(visibility),
       },
     };
-    const options: FindOneAndUpdateOptions = {
+    const options = {
       returnDocument: 'after',
-    };
+      includeResultMetadata: true,
+    } satisfies FindOneAndUpdateOptions;
 
     if (opts.resetTries) {
       update.$set = {
@@ -212,9 +214,10 @@ export default class Queue<T = any> {
         deleted: now(),
       },
     };
-    const options: FindOneAndUpdateOptions = {
+    const options = {
       returnDocument: 'after',
-    };
+      includeResultMetadata: true,
+    } satisfies FindOneAndUpdateOptions;
     const msg = await this.col.findOneAndUpdate(query, update, options);
     if (!msg.value) {
       throw new Error('Queue.ack(): Unidentified ack : ' + ack);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {
@@ -15,11 +15,12 @@
     "eslint": "^8.35.0",
     "mongodb4": "npm:mongodb@^4.0.0",
     "mongodb5": "npm:mongodb@^5.0.0",
+    "mongodb6": "npm:mongodb@^6.0.0",
     "tape": "^4.10.1",
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "mongodb": "^4.0.0 || ^5.0.0"
+    "mongodb": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "homepage": "https://github.com/chilts/mongodb-queue",
   "repository": {


### PR DESCRIPTION
This change adds support for [`mongodb@6`][1]. The main change that affects this library is that `findOneAndUpdate()` now returns the document itself by default, and metadata must be explicitly requested with `includeResultMetadata: true`, which we set to make this library work with v4-6 of `mongodb`.

[1]: https://github.com/mongodb/node-mongodb-native/releases/tag/v6.0.0