### PR TITLE
🐛 Remove undefined props

### DIFF
--- a/mongodb-queue.ts
+++ b/mongodb-queue.ts
@@ -118,7 +118,7 @@ export default class Queue<T = any> {
       });
     }
 
-    const results = await this.col.insertMany(msgs);
+    const results = await this.col.insertMany(msgs, {ignoreUndefined: true});
     if (payload instanceof Array) return '' + results.insertedIds;
     return '' + results.insertedIds[0];
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {

--- a/test/default.js
+++ b/test/default.js
@@ -56,6 +56,17 @@ setup().then(({client, db}) => {
     t.end();
   });
 
+  test('remove undefined properties', async function(t) {
+    const queue = new MongoDbQueue(db, 'default');
+    const id = await queue.add({text: 'Hello, World!', undefinedProp: undefined});
+    t.ok(id, 'Received an id for this message');
+
+    const msg = await queue.get();
+    t.ok(msg.id, 'Got a msg.id');
+    t.equal('undefinedProp' in msg.payload, false, 'Payload has undefinedProp and it should be removed');
+    t.end();
+  });
+
   test('client.close()', function(t) {
     t.pass('client.close()');
     client.close();


### PR DESCRIPTION
At the moment when we pass payload like this:
```ts
{someProp: undefined}
```

It stores it mongoDb Db, but it auto convert it to null value, however it might be error prone as we may enqueue job that has `callbackUrl: undefined`, then the mongo queue saves in db, which converts it to `callbackUrl: null`, then when getting the message from queue worker validate the job payload and has type `t.partial({callbackUrl: t.string}})`. The validation will fail.