### PR TITLE
💥 Remove default exports

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,3 +4,13 @@ parserOptions:
   project: './tsconfig.json'
 env:
   node: true
+rules:
+  # default exports have bad CJS/ESM interoperability
+  no-restricted-exports:
+    - error
+    - restrictDefaultExports:
+        direct: true
+        named: true
+        defaultFrom: true
+        namedFrom: true
+        namespaceFrom: true

--- a/mongodb-queue.ts
+++ b/mongodb-queue.ts
@@ -28,7 +28,7 @@ function nowPlusSecs(secs: number): string {
 export type QueueOptions = {
   visibility?: number;
   delay?: number;
-  deadQueue?: Queue;
+  deadQueue?: MongoDBQueue;
   maxRetries?: number;
 };
 
@@ -63,12 +63,12 @@ export type ExternalMessage<T = any> = {
   tries: number;
 };
 
-export default class Queue<T = any> {
+export class MongoDBQueue<T = any> {
   private readonly col: Collection<Partial<Message<T>>>;
   private readonly visibility: number;
   private readonly delay: number;
   private readonly maxRetries: number;
-  private readonly deadQueue: Queue;
+  private readonly deadQueue: MongoDBQueue;
 
   public constructor(db: Db, name: string, opts: QueueOptions = {}) {
     if (!db) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {

--- a/test/clean.js
+++ b/test/clean.js
@@ -1,11 +1,11 @@
 const test = require('tape');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 
 setup().then(({client, db}) => {
   test('clean: check deleted messages are deleted', async function(t) {
-    const q = new MongoDbQueue(db, 'clean', {visibility: 3});
+    const q = new MongoDBQueue(db, 'clean', {visibility: 3});
 
     t.equal(await q.size(), 0, 'There is currently nothing on the queue');
     t.equal(await q.total(), 0, 'There is currently nothing in the queue at all');

--- a/test/dead-queue.js
+++ b/test/dead-queue.js
@@ -1,18 +1,18 @@
 const test = require('tape');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 
 setup().then(({client, db}) => {
   test('first test', function(t) {
-    const queue = new MongoDbQueue(db, 'queue', {visibility: 3, deadQueue: 'dead-queue'});
+    const queue = new MongoDBQueue(db, 'queue', {visibility: 3, deadQueue: 'dead-queue'});
     t.ok(queue, 'Queue created ok');
     t.end();
   });
 
   test('single message going over 5 tries, should appear on dead-queue', async function(t) {
-    const deadQueue = new MongoDbQueue(db, 'dead-queue');
-    const queue = new MongoDbQueue(db, 'queue', {visibility: 1, deadQueue: deadQueue});
+    const deadQueue = new MongoDBQueue(db, 'dead-queue');
+    const queue = new MongoDBQueue(db, 'queue', {visibility: 1, deadQueue: deadQueue});
     let msg;
 
     const origId = await queue.add('Hello, World!');
@@ -41,8 +41,8 @@ setup().then(({client, db}) => {
   });
 
   test('two messages, with first going over 3 tries', async function(t) {
-    const deadQueue = new MongoDbQueue(db, 'dead-queue-2');
-    const queue = new MongoDbQueue(db, 'queue-2', {visibility: 1, deadQueue: deadQueue, maxRetries: 3});
+    const deadQueue = new MongoDBQueue(db, 'dead-queue-2');
+    const queue = new MongoDBQueue(db, 'queue-2', {visibility: 1, deadQueue: deadQueue, maxRetries: 3});
     let msg;
 
     const origId = await queue.add('Hello, World!');

--- a/test/default.js
+++ b/test/default.js
@@ -1,17 +1,17 @@
 const test = require('tape');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 
 setup().then(({client, db}) => {
   test('first test', function(t) {
-    const queue = new MongoDbQueue(db, 'default');
+    const queue = new MongoDBQueue(db, 'default');
     t.ok(queue, 'Queue created ok');
     t.end();
   });
 
   test('single round trip', async function(t) {
-    const queue = new MongoDbQueue(db, 'default');
+    const queue = new MongoDBQueue(db, 'default');
     let id;
 
     id = await queue.add('Hello, World!');
@@ -33,7 +33,7 @@ setup().then(({client, db}) => {
   });
 
   test("single round trip, can't be acked again", async function(t) {
-    const queue = new MongoDbQueue(db, 'default');
+    const queue = new MongoDBQueue(db, 'default');
     let id;
 
     id = await queue.add('Hello, World!');
@@ -57,7 +57,7 @@ setup().then(({client, db}) => {
   });
 
   test('remove undefined properties', async function(t) {
-    const queue = new MongoDbQueue(db, 'default');
+    const queue = new MongoDBQueue(db, 'default');
     const id = await queue.add({text: 'Hello, World!', undefinedProp: undefined});
     t.ok(id, 'Received an id for this message');
 

--- a/test/delay.js
+++ b/test/delay.js
@@ -1,12 +1,12 @@
 const test = require('tape');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 const {timeout} = require('./_timeout.js');
 
 setup().then(({client, db}) => {
   test('delay: check messages on this queue are returned after the delay', async function(t) {
-    const queue = new MongoDbQueue(db, 'delay', {delay: 3});
+    const queue = new MongoDBQueue(db, 'delay', {delay: 3});
     let msg;
 
     const id = await queue.add('Hello, World!');
@@ -27,7 +27,7 @@ setup().then(({client, db}) => {
   });
 
   test('delay: check an individual message delay overrides the queue delay', async function(t) {
-    const queue = new MongoDbQueue(db, 'delay');
+    const queue = new MongoDBQueue(db, 'delay');
     let msg;
 
     const id = await queue.add('I am delayed by 3 seconds', {delay: 3});

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -1,11 +1,11 @@
 const test = require('tape');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 
 setup().then(({client, db}) => {
   test('visibility: check message is back in queue after 3s', async function(t) {
-    const queue = new MongoDbQueue(db, 'visibility', {visibility: 3});
+    const queue = new MongoDBQueue(db, 'visibility', {visibility: 3});
 
     await queue.createIndexes();
     t.pass('Indexes created');

--- a/test/many.js
+++ b/test/many.js
@@ -1,13 +1,13 @@
 const test = require('tape');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 
 const total = 250;
 
 setup().then(({client, db}) => {
   test('many: add ' + total + ' messages, get ' + total + ' back', async function(t) {
-    const queue = new MongoDbQueue(db, 'many');
+    const queue = new MongoDBQueue(db, 'many');
     const msgs = [];
     const msgsToQueue = [];
 
@@ -36,7 +36,7 @@ setup().then(({client, db}) => {
   });
 
   test('many: add no messages, receive err in callback', async function(t) {
-    const queue = new MongoDbQueue(db, 'many');
+    const queue = new MongoDBQueue(db, 'many');
     await queue.add([])
       .catch(() => t.pass('got error'));
     t.end();

--- a/test/multi.js
+++ b/test/multi.js
@@ -1,13 +1,13 @@
 const test = require('tape');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 
 const total = 250;
 
 setup().then(({client, db}) => {
   test('multi: add ' + total + ' messages, get ' + total + ' back', async function(t) {
-    const queue = new MongoDbQueue(db, 'multi');
+    const queue = new MongoDBQueue(db, 'multi');
     const msgs = [];
 
     for (let i = 0; i < total; i++) await queue.add('no=' + i);

--- a/test/ping.js
+++ b/test/ping.js
@@ -2,11 +2,11 @@ const test = require('tape');
 const {timeout} = require('./_timeout');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 
 setup().then(({client, db}) => {
   test('ping: check a retrieved message with a ping can still be acked', async function(t) {
-    const queue = new MongoDbQueue(db, 'ping', {visibility: 5});
+    const queue = new MongoDBQueue(db, 'ping', {visibility: 5});
     let msg;
     let id;
 
@@ -30,7 +30,7 @@ setup().then(({client, db}) => {
   });
 
   test("ping: check that an acked message can't be pinged", async function(t) {
-    const queue = new MongoDbQueue(db, 'ping', {visibility: 5});
+    const queue = new MongoDBQueue(db, 'ping', {visibility: 5});
     let id;
 
     id = await queue.add('Hello, World!');
@@ -51,7 +51,7 @@ setup().then(({client, db}) => {
   });
 
   test('ping: check visibility option overrides the queue visibility', async function(t) {
-    const queue = new MongoDbQueue(db, 'ping', {visibility: 3});
+    const queue = new MongoDBQueue(db, 'ping', {visibility: 3});
     let msg;
     let id;
 
@@ -84,7 +84,7 @@ setup().then(({client, db}) => {
   });
 
   test('ping: reset tries', async function(t) {
-    const queue = new MongoDbQueue(db, 'ping', {visibility: 3});
+    const queue = new MongoDBQueue(db, 'ping', {visibility: 3});
     let msg;
     let id;
 

--- a/test/stats.js
+++ b/test/stats.js
@@ -2,17 +2,17 @@ const test = require('tape');
 const {timeout} = require('./_timeout');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 
 setup().then(({client, db}) => {
   test('first test', function(t) {
-    const queue = new MongoDbQueue(db, 'stats');
+    const queue = new MongoDBQueue(db, 'stats');
     t.ok(queue, 'Queue created ok');
     t.end();
   });
 
   test('stats for a single message added, received and acked', async function(t) {
-    const q = new MongoDbQueue(db, 'stats1');
+    const q = new MongoDBQueue(db, 'stats1');
 
     const id = await q.add('Hello, World!');
     t.ok(id, 'Received an id for this message');
@@ -39,7 +39,7 @@ setup().then(({client, db}) => {
   // then re-checking all stats.
 
   test('stats for a single message added, received, timed-out and back on queue', async function(t) {
-    const q = new MongoDbQueue(db, 'stats2', {visibility: 3});
+    const q = new MongoDBQueue(db, 'stats2', {visibility: 3});
 
     const id = await q.add('Hello, World!');
     t.ok(id, 'Received an id for this message');

--- a/test/visibility.js
+++ b/test/visibility.js
@@ -2,11 +2,11 @@ const test = require('tape');
 const {timeout} = require('./_timeout');
 
 const setup = require('./setup.js');
-const MongoDbQueue = require('../').default;
+const {MongoDBQueue} = require('../');
 
 setup().then(({client, db}) => {
   test('visibility: check message is back in queue after 3s', async function(t) {
-    const queue = new MongoDbQueue(db, 'visibility', {visibility: 3});
+    const queue = new MongoDBQueue(db, 'visibility', {visibility: 3});
     let msg;
 
     await queue.add('Hello, World!');
@@ -25,7 +25,7 @@ setup().then(({client, db}) => {
   });
 
   test("visibility: check that a late ack doesn't remove the msg", async function(t) {
-    const queue = new MongoDbQueue(db, 'visibility', {visibility: 3});
+    const queue = new MongoDBQueue(db, 'visibility', {visibility: 3});
     let msg;
 
     await queue.add('Hello, World!');
@@ -59,7 +59,7 @@ setup().then(({client, db}) => {
   });
 
   test('visibility: check visibility option overrides the queue visibility', async function(t) {
-    const queue = new MongoDbQueue(db, 'visibility', {visibility: 2});
+    const queue = new MongoDBQueue(db, 'visibility', {visibility: 2});
     let msg;
 
     await queue.add('Hello, World!');


### PR DESCRIPTION
Default exports have [bad interoperability][1] between Common JS and ES Module imports, so the safest thing to do is just remove them.

This is a **BREAKING** change which removes our export default statements, and adds a linter rule to prevent us from adding them.

[1]: https://github.com/evanw/esbuild/issues/1719#issuecomment-953470495