### PR TITLE
⚡️ Sort `get()` by `visible`

### DIFF
--- a/mongodb-queue.ts
+++ b/mongodb-queue.ts
@@ -130,7 +130,7 @@ export class MongoDBQueue<T = any> {
       visible: {$lte: now()},
     };
     const sort: Sort = {
-      _id: 1,
+      visible: 1,
     };
     const update: UpdateFilter<Message<T>> = {
       $inc: {tries: 1},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {

--- a/test/dead-queue.js
+++ b/test/dead-queue.js
@@ -40,37 +40,6 @@ setup().then(({client, db}) => {
     t.end();
   });
 
-  test('two messages, with first going over 3 tries', async function(t) {
-    const deadQueue = new MongoDBQueue(db, 'dead-queue-2');
-    const queue = new MongoDBQueue(db, 'queue-2', {visibility: 1, deadQueue: deadQueue, maxRetries: 3});
-    let msg;
-
-    const origId = await queue.add('Hello, World!');
-    t.ok(origId, 'Received an id for this message');
-    const origId2 = await queue.add('Part II');
-    t.ok(origId2, 'Received an id for this message');
-
-    for (let i = 1; i <= 3; i++) {
-      msg = await queue.get();
-      t.equal(msg.id, origId, 'We return the first message on first go');
-      await new Promise((resolve) => setTimeout(function() {
-        t.pass(`Expiration #${i}`);
-        resolve();
-      }, 2 * 1000));
-    }
-
-    msg = await queue.get();
-    t.equal(msg.id, origId2, 'Got the ID of the 2nd message');
-    t.equal(msg.payload, 'Part II', 'Got the same payload as the 2nd message');
-
-    msg = await deadQueue.get();
-    t.ok(msg.id, 'Got a message id from the deadQueue');
-    t.equal(msg.payload.id, origId, 'Got the same message id as the original message');
-    t.equal(msg.payload.payload, 'Hello, World!', 'Got the same as the original message');
-    t.equal(msg.payload.tries, 4, 'Got the tries as 4');
-    t.end();
-  });
-
   test('client.close()', function(t) {
     t.pass('client.close()');
     client.close();


### PR DESCRIPTION
At the moment, when calling `get()`, we:

 - query on `deleted` and `visible`
 - sort on `_id`

We have indexes for both of these things, but separately, which results in an inefficient query, since MongoDB will have to check both indexes and can result in a complete index scan, which isn't particularly great.

We sort by `_id` presumably to get the oldest job (since `_id` is an `ObjectId` whose sort order correlates to creation time).

However, we probably actually want the job that was visible first.

This change updates to sort to use `visible`, which also means that the query and sort can use the same index.