### PR TITLE
🗃 Change `ack` to (string) `ObjectId`

### DIFF
--- a/mongodb-queue.ts
+++ b/mongodb-queue.ts
@@ -10,12 +10,7 @@
  *
  **/
 
-import {randomBytes} from 'crypto';
-import {Collection, Db, Filter, FindOneAndUpdateOptions, Sort, UpdateFilter, WithId} from 'mongodb';
-
-function id(): string {
-  return randomBytes(16).toString('hex');
-}
+import {Collection, Db, Filter, FindOneAndUpdateOptions, ObjectId, Sort, UpdateFilter, WithId} from 'mongodb';
 
 function now(): string {
   return (new Date()).toISOString();
@@ -135,7 +130,7 @@ export class MongoDBQueue<T = any> {
     const update: UpdateFilter<Message<T>> = {
       $inc: {tries: 1},
       $set: {
-        ack: id(),
+        ack: new ObjectId().toHexString(),
         visible: nowPlusSecs(visibility),
       },
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {


### PR DESCRIPTION
At the moment, the `ack` is a completely random hex string.

This change updates it to use an `ObjectId`, which:

 - encodes information about the time the job was pulled (for the first time)
 - ...and can therefore be used to sort jobs in the order they were originally pulled from the queue
 - allows us to simplify the dependencies and code a little