### PR TITLE
🗃 Remove `visible` when acking jobs

### DIFF
--- a/mongodb-queue.ts
+++ b/mongodb-queue.ts
@@ -208,6 +208,9 @@ export class MongoDBQueue<T = any> {
       $set: {
         deleted: now(),
       },
+      $unset: {
+        visible: 1,
+      },
     };
     const options = {
       returnDocument: 'after',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {


### PR DESCRIPTION
This is a non-breaking change that forms part of the migration path to improving our performance in https://github.com/reedsy/mongodb-queue/pull/15

When acking a job, we now unset the `visible` property, which makes `visible` and `deleted` mutually exclusive properties, so that the presence of one implies the absence of the other.

We can do this, because the only time we query on `visible` is when we *also* query for `deleted: {$exists: false}`. Similarly, the only times we query for `deleted: {$exists: true}` are times when we don't query `visible`.