### PR TITLE
💥 Change `deleted` from `string` to `Date`

### DIFF
--- a/mongodb-queue.ts
+++ b/mongodb-queue.ts
@@ -48,7 +48,7 @@ export type BaseMessage<T = any> = {
 export type Message<T = any> = BaseMessage<T> & {
   ack: string;
   tries: number;
-  deleted?: string;
+  deleted?: Date;
 };
 
 export type ExternalMessage<T = any> = {
@@ -206,7 +206,7 @@ export class MongoDBQueue<T = any> {
     };
     const update: UpdateFilter<Message<T>> = {
       $set: {
-        deleted: now(),
+        deleted: new Date(),
       },
       $unset: {
         visible: 1,


### PR DESCRIPTION
This is a **BREAKING** change that will change the `deleted` field from a `string` to a `Date`, which will let us set up a TTL index on it.

Although this change is technically breaking, it should be deployable with no impact on Production, since we only ever query `deleted` using the `$exists` operator.

In order to leverage the TTL index, we'll need to:

 1. Deploy this change
 2. Migrate all existing `deleted` fields to `Date`: 
    ```js
    db.collection.update(
      {deleted: {$type: "string"}},
      [{$set: {deleted: {$toDate: "$deleted"}}}]
    )
    ```
 3. Change the existing `deleted` index to TTL:
    ```js
    db.runCommand({
      collMod: '...',
      index: {
        name: 'deleted_1',
        expireAfterSeconds: 2592000, // ~ 1 month
      }
    })
    ```