### PR TITLE
✨ Allow optional TTL on `deleted` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {


### PR DESCRIPTION
Now that `deleted` is a `Date`, we can add a TTL index to it. This change adds an optional `expireAfterSeconds` option, which is passed through to the `deleted` index options if set to a `number`.