### PR TITLE
✨ Allow resetting `ack` when calling `ping()`

### DIFF
--- a/mongodb-queue.ts
+++ b/mongodb-queue.ts
@@ -39,6 +39,7 @@ export type GetOptions = {
 export type PingOptions = {
   visibility?: number;
   resetTries?: boolean;
+  resetAck?: boolean;
 };
 
 export type BaseMessage<T = any> = {
@@ -203,6 +204,10 @@ export class MongoDBQueue<T = any> {
         ...update.$set,
         tries: 0,
       };
+    }
+
+    if (opts.resetAck) {
+      update.$unset = {ack: 1};
     }
 
     const msg = await this.col.findOneAndUpdate(query, update, options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/mongodb-queue",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Message queues which uses MongoDB.",
   "main": "mongodb-queue.js",
   "scripts": {


### PR DESCRIPTION
At the moment, when calling:

```js
queue.ping({resetTries: true})
```

The tries are reset as if the job hasn't been picked up, but the `ack` is left as-is.

This isn't necessarily problematic in the operation of the queue, but it does mean that the pinged job will still show up as [in-flight][1].

This change adds an optional `resetAck` flag, which will also unset the `ack`, and means that the job can be marked as not in-flight, as if it has never been picked up.

[1]: https://github.com/reedsy/mongodb-queue/blob/6133fc9367f4fce719e36d8866841d531e956b6b/mongodb-queue.ts#L262